### PR TITLE
docs: rewrite README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,46 +1,81 @@
-# Getting Started with Create React App
+# Beef Cuts App
 
-This project was bootstrapped with [Create React App](https://github.com/facebook/create-react-app).
+An interactive, multilingual reference application that showcases the primary cuts of beef.
+Users can hover over the illustrated map to explore individual cuts, read localized
+information about each piece, and review a steak doneness guide. The experience is
+personalized through a language selector that updates the interface and can be deep-linked
+through a `lang` query parameter.
 
-## Available Scripts
+## Features
 
-In the project directory, you can run:
+- **Interactive map:** Hover over the beef diagram to highlight individual cuts and view
+  details in the side panel.
+- **Multilingual support:** Switch between English, French, Italian, Spanish, German,
+  Dutch, and Portuguese via the built-in language picker. The current language is reflected
+  in the page URL so you can bookmark or share it.
+- **Steak doneness reference:** A quick table that outlines common doneness levels
+  translated into the selected language.
+- **Referral & contact information:** Links to partner services and the creator's contact
+  details are available directly in the app footer.
 
-### `npm start`
+## Getting Started
 
-Runs the app in the development mode.\
-Open [http://localhost:3000](http://localhost:3000) to view it in the browser.
+### Prerequisites
 
-The page will reload if you make edits.\
-You will also see any lint errors in the console.
+- [Node.js](https://nodejs.org/) (version 18 or later is recommended)
+- npm (bundled with Node.js)
 
-### `npm test`
+### Installation
 
-Launches the test runner in the interactive watch mode.\
-See the section about [running tests](https://facebook.github.io/create-react-app/docs/running-tests) for more information.
+```bash
+npm install
+```
 
-### `npm run build`
+### Local development
 
-Builds the app for production to the `build` folder.\
-It correctly bundles React in production mode and optimizes the build for the best performance.
+Run the development server and open [http://localhost:3000](http://localhost:3000) in your
+browser. The app will reload automatically when you edit source files.
 
-The build is minified and the filenames include the hashes.\
-Your app is ready to be deployed!
+```bash
+npm start
+```
 
-See the section about [deployment](https://facebook.github.io/create-react-app/docs/deployment) for more information.
+### Running tests
 
-### `npm run eject`
+Launch the interactive test runner. Press `a` to run all tests or `q` to quit the watcher.
 
-**Note: this is a one-way operation. Once you `eject`, you can’t go back!**
+```bash
+npm test
+```
 
-If you aren’t satisfied with the build tool and configuration choices, you can `eject` at any time. This command will remove the single build dependency from your project.
+### Production build
 
-Instead, it will copy all the configuration files and the transitive dependencies (webpack, Babel, ESLint, etc) right into your project so you have full control over them. All of the commands except `eject` will still work, but they will point to the copied scripts so you can tweak them. At this point you’re on your own.
+Create an optimized production build in the `build` directory.
 
-You don’t have to ever use `eject`. The curated feature set is suitable for small and middle deployments, and you shouldn’t feel obligated to use this feature. However we understand that this tool wouldn’t be useful if you couldn’t customize it when you are ready for it.
+```bash
+npm run build
+```
 
-## Learn More
+## Project Structure
 
-You can learn more in the [Create React App documentation](https://facebook.github.io/create-react-app/docs/getting-started).
+```
+src/
+  App.tsx            # Top-level layout, language selection, and routing of components
+  components/        # Interactive map, cut information panel, translations, and tables
+  assets/            # Images and static resources for the beef cuts diagram
+  beefcuts.ts        # Data describing each cut shown in the map and info panel
+```
 
-To learn React, check out the [React documentation](https://reactjs.org/).
+## Customization Tips
+
+- **Adding a new language:** Update the translation utilities in `src/components/Translator`
+  and extend any data files that provide localized strings.
+- **Changing the map or cut data:** Modify the SVG assets in `src/assets/` and adjust the
+  metadata in `src/beefcuts.ts` to keep the map labels and descriptions in sync.
+- **Sharing localized views:** Append `?lang=<language>` (e.g., `?lang=spanish`) to the app
+  URL to load the interface in a specific language by default.
+
+## License
+
+This project was bootstrapped with Create React App. Consult the repository owner for
+licensing and usage terms before distributing or deploying the application.


### PR DESCRIPTION
## Summary
- replace the Create React App boilerplate README with project-specific documentation
- describe the app's purpose, multilingual features, and steak doneness guide
- add setup, testing, build instructions, project structure, and customization tips

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d65a04ef7c8325a823f82f44bbb15d